### PR TITLE
Add instruction on how run it locally to test production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ website/build/
 website/yarn.lock
 website/node_modules
 website/i18n/*
+website/protocol

--- a/README.md
+++ b/README.md
@@ -3,18 +3,43 @@
 What are these docs about...
 
 ## Installation
+
 > You have to be on Node >= 8.x and Yarn >= 1.5.
 
 ```sh
 yarn i
-````
+```
 
 ## Run website
 
 ```sh
 cd website
+
+# Run it for development
 yarn start
+
+# It can be convenient to make sure the paths and links are ok even when we change the base url
+BASE_URL=/protocol/ yarn start
 ```
+
+# Build for production
+
+```bash
+yarn build
+```
+
+It's a good idea to preview the production version, because there can be small differences with the development,
+specially related to resource paths and links:
+
+```bash
+# Build and run app changing the base url
+BASE_URL=/protocol/ yarn build && \
+  rm -rf protocol && \
+  mv build/dfusion-docs protocol \
+  && npx serve .
+```
+
+Then access <http://localhost:5000/protocol>
 
 ## More info
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ cd website
 # Run it for development
 yarn start
 
-# It can be convenient to make sure the paths and links are ok even when we change the base url
-BASE_URL=/protocol/ yarn start
+# It you want to try with a different base url
+BASE_URL=/ yarn start
 ```
+
+**Gotchas**: If in production you have some issues displaying some images, and it doesn't reproduce in the local dev
+server, try to add a `/` at the end of the problematic URL. Docusaurus v1 can have issues serving static files from
+those URLs.
 
 # Build for production
 
@@ -33,13 +37,13 @@ specially related to resource paths and links:
 
 ```bash
 # Build and run app changing the base url
-BASE_URL=/protocol/ yarn build && \
+yarn build && \
   rm -rf protocol && \
   mv build/dfusion-docs protocol \
   && npx serve .
 ```
 
-Then access <http://localhost:5000/protocol>
+Then access <http://localhost:5000/protocol/>
 
 ## More info
 

--- a/docs/tutorial-telegram-bot.md
+++ b/docs/tutorial-telegram-bot.md
@@ -15,8 +15,11 @@ Prerequisites:
 
 ### What is a Gnosis Protocol (GP) Telegram Bot?
 
-<img src="assets/tutorial-telegram-bot/telegram-messages.png" width="450" align="right" />
-GP Telegram bot is an open source Node.js app that listens for Ethereum events on Gnosis Protocol smart contracts, and sends notifications in a clear format to any Telegram channel.
+<img src="/protocol/docs/assets/tutorial-telegram-bot/telegram-messages.png" width="450" align="right" />
+
+GP Telegram bot is an open source Node.js app that listens for Ethereum events on
+Gnosis Protocol smart contracts, and sends notifications in a clear format to any
+Telegram channel.
 
 At the time of writing (June 2020), the bot is configured to send a notification every time any user **submits a new order** on the protocol (_Note: Submitting an order is independent of a user's balance on the protocol, and the order may also be cancelled_). Using the bot, you can watch all markets, or you can specify a list of tokens for your Telegram channel to watch.
 
@@ -62,7 +65,7 @@ The process for creating a bot is super simple:
 
 The entire process should look like this:
 
-<img src="assets/tutorial-telegram-bot/telegram-create-bot.png" width="400" />
+<img src="/protocol/docs/assets/tutorial-telegram-bot/telegram-create-bot.png" width="400" />
 
 Notice the red arrow. That's your authentication token. It's required to authenticate your bot's services and notifications.
 
@@ -71,14 +74,25 @@ Notice the red arrow. That's your authentication token. It's required to authent
 You will need to have a Telegram channel in which the bot sends notifications.
 
 Create a channel using your Telegram client:\
-<img src="assets/tutorial-telegram-bot/telegram-create-channel-1.png" width="650" />
+
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-create-channel-1.png"
+  width="650"
+/>
 
 Give the channel a name:\
-<img src="assets/tutorial-telegram-bot/telegram-create-channel-2.png" width="650" />
+
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-create-channel-2.png"
+  width="650"
+/>
 
 Make sure the channel is public, and it has a name you like:
 
-<img src="assets/tutorial-telegram-bot/telegram-create-channel-3.png" width="450" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-create-channel-3.png"
+  width="450"
+/>
 
 Save the name of the channel for later as we'll need it for the configuration. In this case, we've named our channel `@potato_token`.
 
@@ -90,23 +104,38 @@ Useful resource:
 
 Click on the channel header to enter the bot's details as an administrator:
 
-<img src="assets/tutorial-telegram-bot/telegram-bot-permissions-1.png" width="450" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-bot-permissions-1.png"
+  width="450"
+/>
 
 Edit the administrators:
 
-<img src="assets/tutorial-telegram-bot/telegram-bot-permissions-2.png" width="450" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-bot-permissions-2.png"
+  width="450"
+/>
 
 Add the bot as administrator:
 
-<img src="assets/tutorial-telegram-bot/telegram-bot-permissions-3.png" width="450" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-bot-permissions-3.png"
+  width="450"
+/>
 
 Make sure the bot can post messages:
 
-<img src="assets/tutorial-telegram-bot/telegram-bot-permissions-4.png" width="450" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-bot-permissions-4.png"
+  width="450"
+/>
 
 You should now have a new administrator in the channel:
 
-<img src="assets/tutorial-telegram-bot/telegram-bot-permissions-5.png" width="450" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-bot-permissions-5.png"
+  width="450"
+/>
 
 ## 🧠 4\. Setup the bot (create a config file)
 
@@ -176,7 +205,7 @@ yarn dev
 
 If everything runs as planned, you should see something similar to this:
 
-<img src="assets/tutorial-telegram-bot/telegram-run-output.png" width="10024" />
+<img src="/protocol/docs/assets/tutorial-telegram-bot/telegram-run-output.png" width="10024" />
 
 ### Alternatively you can run it with Docker
 
@@ -200,7 +229,7 @@ Visit any Gnosis Protocol dapp like the Potato Exchange or [Mesa](http://mesa.et
 
 The channel should now receive a notification from the bot:
 
-<img src="assets/tutorial-telegram-bot/telegram-messages.png" width="650" />
+<img src="/protocol/docs/assets/tutorial-telegram-bot/telegram-messages.png" width="650" />
 
 If it does not work or you need help, find us on [Discord](http://chat.gnosis.io).
 
@@ -210,11 +239,17 @@ The bot, like any piece of software relying on network access, can have connecti
 
 One nice thing about the bot, is that we can can try to talk to it, and see if it replies:
 
-<img src="assets/tutorial-telegram-bot/telegram-about-command-1.png" width="650" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-about-command-1.png"
+  width="650"
+/>
 
 Also, it has a convenient `/about` command that would give you a lot of useful information, such us the running version of the bot, the contract that it is watching, the network it's listening to, and the last mined Ethereum block that it is aware of:
 
-<img src="assets/tutorial-telegram-bot/telegram-about-command-2.png" width="650" />
+<img
+  src="/protocol/docs/assets/tutorial-telegram-bot/telegram-about-command-2.png"
+  width="650"
+/>
 
 The last mined block can be useful if we suspect that for some reason the bot is disconnected from the node. This way, we can check if this block is recent or not, for example by comparing it with the last mined block we see on [etherscan.io](https://etherscan.io/).
 

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -20,7 +20,7 @@ const users = [
   // },
 ];
 
-const baseUrl = process.env.BASE_URL || "/";
+const baseUrl = process.env.BASE_URL || '/protocol/';
 
 const siteConfig = {
   title: 'Gnosis Developer Portal Gnosis Protocol ', // Title for your website.


### PR DESCRIPTION
This PRs:
* Adds instructions on how to run the docs locally but changing the base url
* Also gives you a command you can use to build and run the web in production mode, to debug any issue with resource resolution or links.
* Set's absolute paths for the telegram bot, to fix image resolution issues


## Issue why this PR was created in the first place
This PR was created to try to reproduce locally. But locally it works, changing the base url and without changing it. Also in dev mode and building it for production too. 

The images are broken in https://dfusion-docs.dev.gnosisdev.com/protocol/docs/tutorial-telegram-bot/

If you follow the instructions in the README, it should work for though: http://localhost:5000/protocol/docs/tutorial-telegram-bot

Interestingly the images that use PURE markdown (instead of img tag) work https://dfusion-docs.dev.gnosisdev.com/protocol/docs/tutorial-limit-orders/

In travis we can see how:
* It was constructed for DEV: https://travis-ci.com/github/gnosis/dex-docs/builds/173649949
* Used `BASE_URL=/protocol/`

![image](https://user-images.githubusercontent.com/2352112/86226539-1cba2c00-bb8c-11ea-905d-fecdb17a7714.png)

For making things crazier, if we deploy it to another http server, even changing the base URL, it works: https://courageous-knot.surge.sh/protocol/docs/tutorial-telegram-bot


## EDIT: After reviewing the case
* Docusaurus v1 have issues with basePath resolution in images defined as `<img>` tags, IF the URL ends in a `/`
* Apparently Cloudfront requires the urls to end in `/`
* There's a variation of markdown that allows to set width or aligments using `![]{ width: 70% }(img)`. It doesn't work in docusaurus v1 😢
* Last resource was using absolute path. Not pretty but at least it works 