### PR TITLE
Fix Nav Bar on smaller screens

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -467,6 +467,10 @@ a{
 
 /* Fix for  Navigation Bar on smaller screens*/
 @media only screen and (max-width: 1023px) {
+   .fixedHeaderContainer {
+      position: relative;
+   }
+   
    .docsNavContainer {
       top: 0;
       position: sticky;

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -464,3 +464,62 @@ a{
    color: $primaryColor;
    text-decoration: underline;
 }
+
+/* Fix for  Navigation Bar on smaller screens*/
+@media only screen and (max-width: 1023px) {
+   .docsNavContainer {
+      top: 0;
+      position: sticky;
+      margin-left: -20px;
+      width: 100vw;
+   }
+
+   .docsSliderActive.docsNavContainer {
+      padding-bottom: 0;
+   }
+
+   .tocActive .onPageNav {
+      position: sticky;
+      top: 48px;
+      width: 100vw;
+      margin-left: -20px;
+  }
+
+  .tocActive .docMainWrapper.wrapper {
+     display: flex;
+     flex-direction: column;
+  }
+
+  .tocActive .mainContainer {
+     order: 2;
+  }
+
+  .docsNavContainer .toc .navBreadcrumb {
+     position: static;
+  }
+
+  .docsSliderActive .toc section .navGroups {
+     padding-top: 0;
+     padding-bottom: 0;
+  }
+
+  .tocToggler {
+     margin-right: 0;
+  }
+
+  .tocActive .toggleNav .navBreadcrumb {
+     margin-bottom: 0;
+   }
+
+   .navPusher {
+      padding-top: 0;
+   }
+
+   .tocActive .docsSliderActive .toggleNav .navGroups {
+      display: none;
+  }
+
+  .line1, .line2, .line3 {
+      transition-property: transfrom;
+   }
+}


### PR DESCRIPTION
Nav Bar is fixed in the center of the screen. Nav sections overlay over each other.

BEFORE:
![before](https://user-images.githubusercontent.com/5121491/86914870-b1db9880-c129-11ea-849a-55dc5dd1982c.gif)


AFTER: Nav Bar is sticky
![after](https://user-images.githubusercontent.com/5121491/86915781-3b3f9a80-c12b-11ea-9fb3-a7f66b67b4c5.gif)
